### PR TITLE
Update repofile URLs to use public CDN instead of FTP

### DIFF
--- a/roles/common/tasks/determinate-repofile.yml
+++ b/roles/common/tasks/determinate-repofile.yml
@@ -1,0 +1,15 @@
+---
+- name: Set repofile for EL 7
+  ansible.builtin.set_fact:
+    convert2rhel_repofile_url: "https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel/server/7/7Server/x86_64/files/repofile.repo"
+  when: ansible_distribution_major_version | int == 7
+
+- name: Set repofile for EL 8
+  ansible.builtin.set_fact:
+    convert2rhel_repofile_url: "https://cdn-public.redhat.com/content/public/addon/dist/convert2rhel8/8/x86_64/files/repofile.repo"
+  when: ansible_distribution_major_version | int == 8
+
+- name: Display repofile url set
+  ansible.builtin.debug:
+    msg: "{{ convert2rhel_repofile_url }}"
+...

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # tasks file for common
+- name: Determinate repofile for target
+  ansible.builtin.include_tasks: determinate-repofile.yml
 
 - name: Validate source distribution and major version
   ansible.builtin.fail:
@@ -36,7 +38,7 @@
 
     - name: Add Convert2RHEL yum repository from Red Hat
       ansible.builtin.get_url:
-        url:  https://ftp.redhat.com/redhat/convert2rhel/{{ ansible_distribution_major_version }}/convert2rhel.repo
+        url: "{{ convert2rhel_repofile_url }}"
         dest: "/etc/yum.repos.d/convert2rhel.repo"
         mode: '0644'
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
 # tasks file for common
-- name: Determinate repofile for target
-  ansible.builtin.include_tasks: determinate-repofile.yml
-
 - name: Validate source distribution and major version
   ansible.builtin.fail:
     msg: "The system must be CentOS/Oracle/Alma/Rocky Linux 7 or 8"
@@ -35,6 +32,9 @@
         url:  https://www.redhat.com/security/data/fd431d51.txt
         dest: "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
         mode: '0644'
+
+    - name: Determinate repofile for target
+      ansible.builtin.include_tasks: determinate-repofile.yml
 
     - name: Add Convert2RHEL yum repository from Red Hat
       ansible.builtin.get_url:


### PR DESCRIPTION
Convert2RHEL now has a public CDN updated with the latest releases. This commit updates the URL reference to use the public CDN instead of the FTP one.

[RHELC-1433](https://issues.redhat.com/browse/RHELC-1433)