### PR TITLE
Prevent workflows executiong on forks

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,6 +6,7 @@ on: [push, pull_request, workflow_call]  # yamllint disable-line rule:truthy
 jobs:
   ansible-lint:
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -46,6 +46,7 @@ jobs:
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }})
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     strategy:
       matrix:
         ansible:
@@ -113,6 +114,7 @@ jobs:
           '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: Units (Ⓐ${{ matrix.ansible }})
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
       fail-fast: true
@@ -170,6 +172,7 @@ jobs:
           '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: Integration (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     strategy:
       fail-fast: false
       matrix:
@@ -241,7 +244,7 @@ jobs:
   check:  # This job does nothing and is only used for the branch protection
           # or multi-stage CI jobs, like making sure that all tests pass before
           # a publishing job is started.
-    if: always()
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
 
     needs:
       - sanity

--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   docsite:
     name: Lint extra docsite docs and links
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - ansible-lint
       - sanity
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     steps:
       - run: >-
           python -c "assert set([
@@ -31,6 +32,7 @@ jobs:
     needs:
       - prechecks
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     steps:
       - uses: actions/checkout@v4
 
@@ -90,6 +92,7 @@ jobs:
     needs:
       - infra_release
     runs-on: ubuntu-latest
+    if: always() && github.repository == 'redhat-cop/infra.convert2rhel'
     env:
       ANSIBLE_FORCE_COLOR: 1
     steps:


### PR DESCRIPTION
Forks might not always have the same setup as the upstream repositories, to prevent email spams from failed workflows, let's prevent them from running in the forks.