### PR TITLE
Fix namespace for custom facts capture.

### DIFF
--- a/changelogs/fragments/fix_facts_capture.yaml
+++ b/changelogs/fragments/fix_facts_capture.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Save facts pre-conversion to pre_convert2rhel instead of pre_ripu so both can be available in the event of convert2rhel -> ripu.
+...

--- a/roles/analysis/tasks/main.yml
+++ b/roles/analysis/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Capture current ansible_facts for validation after analysis
   ansible.builtin.copy:
     content: "{{ ansible_facts | ansible.builtin.combine({'ansible_local': {}}) }}"
-    dest: /etc/ansible/facts.d/pre_ripu.fact
+    dest: /etc/ansible/facts.d/pre_convert2rhel.fact
     mode: "0644"
     owner: root
     group: root


### PR DESCRIPTION
Change to pre_convert2rhel so that it will not conflict with infra.leapp pre_ripu. Allows retention of pre-rhel facts in the event of convert2rhel -> leapp.