### PR TITLE
Variabilize convert_reboot_timeout.

### DIFF
--- a/changelogs/fragments/reboot_after_conversion_is_done.yml
+++ b/changelogs/fragments/reboot_after_conversion_is_done.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - Add option for the user to choose to reboot the system after the converison.
+  - Add option for the user to choose to reboot the system after the conversion.
 ...

--- a/changelogs/fragments/variabilize_reboot_timeout.yml
+++ b/changelogs/fragments/variabilize_reboot_timeout.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Variabilize reboot timeout (convert_reboot_timeout) such that user can override.
+...

--- a/roles/convert/README.md
+++ b/roles/convert/README.md
@@ -17,6 +17,7 @@ Role Variables
 | convert_os_path | String | $PATH | Option string to override the $PATH variable used on the target node |
 | convert_async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
 | convert_async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
+| convert_reboot_timeout | Int | 900 | Variable used for reboot task reboot_timeout (in seconds) |
 | convert_no_rhsm | Boolean | false |  Set to true to pass --no-rhsm to convert2rhel. User must configure /etc/yum.repos.d RHEL repo file with repo disabled and specify analysis_convert2rhel_repos_enabled. |
 
 ## Red Hat Subscription Manager (RHSM) variables

--- a/roles/convert/defaults/main.yml
+++ b/roles/convert/defaults/main.yml
@@ -11,6 +11,7 @@ convert_os_path: $PATH
 
 convert_async_timeout_maximum: 7200
 convert_async_poll_interval: 60
+convert_reboot_timeout: 900
 
 convert_no_rhsm: false
 ...

--- a/roles/convert/tasks/main.yml
+++ b/roles/convert/tasks/main.yml
@@ -39,8 +39,8 @@
 - name: Reboot if requested
   ansible.builtin.reboot:
     msg: "Host is starting Convert2RHEL!"
-    reboot_timeout: 120
-  timeout: 180
+    reboot_timeout: "{{ convert_reboot_timeout | int }}"
+  timeout: "{{ convert_reboot_timeout | int + 60 }}"
   when: convert_reboot_requested
 
 - name: Remove Convert2RHEL


### PR DESCRIPTION
As we've seen with infra.leapp, some systems, typically baremetal, can take a long time to reboot.