### PR TITLE
Use vault repositories for CentOS 7.

### DIFF
--- a/changelogs/fragments/use_vault_for_centos_7.yml
+++ b/changelogs/fragments/use_vault_for_centos_7.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use vault repositories for CentOS 7.
+
+...

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,6 +1,16 @@
 ---
 # defaults file for common
 
+common_centos7_repos:
+  - CentOS-Base.repo
+  - CentOS-CR.repo
+  - CentOS-Debuginfo.repo
+  - CentOS-fasttrack.repo
+  - CentOS-Media.repo
+  - CentOS-Sources.repo
+  - CentOS-Vault.repo
+  - CentOS-x86_64-kernel.repo
+
 common_centos8_repos:
   - CentOS-Linux-AppStream.repo
   - CentOS-Linux-BaseOS.repo

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -7,6 +7,24 @@
     - ansible_distribution not in common_supported_distribution
     - ansible_distribution_major_version in common_supported_major_version
 
+- name: Patch repositories if dealing with CentOS 7.
+  block:
+    - name: Comment mirrorlist in all repos.
+      ansible.builtin.replace:
+        path: /etc/yum.repos.d/{{ item }}
+        regexp: ^mirrorlist
+        replace: "#mirrorlist"
+      loop: "{{ common_centos7_repos }}"
+      when: ansible_distribution == 'CentOS' and ansible_distribution_major_version | int == 7
+
+    - name: Switch repo to vault.centos.org.
+      ansible.builtin.replace:
+        path: /etc/yum.repos.d/{{ item }}
+        regexp: "#baseurl=http://mirror.centos.org"
+        replace: baseurl=https://vault.centos.org
+      loop: "{{ common_centos7_repos }}"
+      when: ansible_distribution == 'CentOS' and ansible_distribution_major_version | int == 7
+
 - name: Patch repositories if dealing with CentOS 8.
   block:
     - name: Comment mirrorlist in all repos.


### PR DESCRIPTION
The mirror.centos.org repos for CentOS 7 were recently removed.